### PR TITLE
Gui

### DIFF
--- a/PVWatts_API.py
+++ b/PVWatts_API.py
@@ -45,7 +45,7 @@ class PVWatts_Run(object):
         self.annual_ratio = self.output['ac_annual']/self.area
 
     def describe(self):
-        print("Peak Day (max) Ratio: {id.max_ratio}".format(id=self),
-                "Low Day (min) Ratio: {id.min_ratio}".format(id=self),
-                "Avg. Day (median) Ratio: {id.median_ratio}".format(id=self),
-                "Annual Ratio: {id.annual_ratio}".format(id=self), sep="\n")
+        return(f"Peak Day (max) Ratio: {self.max_ratio}"
+        f"\nLow Day (min) Ratio: {self.min_ratio}"
+        f"\nAvg. Day (median) Ratio: {self.median_ratio}"
+        f"\n\nAnnual Ratio: {self.annual_ratio}")

--- a/PVWatts_API.py
+++ b/PVWatts_API.py
@@ -1,5 +1,5 @@
-import pvwatts_request
-import process_output
+from PVWatts_Tool import pvwatts_request
+from PVWatts_Tool import process_output
 
 datetime_reference = "resources/datetime_defaults.csv"
 
@@ -28,6 +28,8 @@ class PVWatts_Run(object):
                                                 azimuth = self.azimuth,
                                                 timeframe = self.timeframe)
 
+        self.ac_annual = self.output['ac_annual']
+
         self.hourly_data = process_output.populate_df(self.output,
                             template=datetime_reference)
 
@@ -45,7 +47,8 @@ class PVWatts_Run(object):
         self.annual_ratio = self.output['ac_annual']/self.area
 
     def describe(self):
-        return(f"Peak Day (max) Ratio: {self.max_ratio}"
-        f"\nLow Day (min) Ratio: {self.min_ratio}"
-        f"\nAvg. Day (median) Ratio: {self.median_ratio}"
-        f"\n\nAnnual Ratio: {self.annual_ratio}")
+        return(f"Peak Day (max) Ratio: {self.max_ratio} (kWh/m^2/day)"
+        f"\nLow Day (min) Ratio: {self.min_ratio} (kWh/m^2/day)"
+        f"\nAvg. Day (median) Ratio: {self.median_ratio} (kWh/m^2/day)"
+        f"\nAnnual Ratio: {self.annual_ratio} (kWh/m^2/yr)"
+        f"\n\nAnnual AC Solar Potential: {self.ac_annual} (kWh)")

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from PVWatts_Tool.__main__ import *

--- a/__main__.py
+++ b/__main__.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#! /usr/bin/env python
 import sys
 from PyQt5 import QtWidgets
 
-import PVWatts_API
-
+from PVWatts_Tool import PVWatts_API
 
 class Window(QtWidgets.QWidget):
 
@@ -12,6 +11,7 @@ class Window(QtWidgets.QWidget):
         self.init_ui()
 
     def init_ui(self):
+        self.first_run = True
         container = QtWidgets.QHBoxLayout()
 
         left_pane = QtWidgets.QVBoxLayout()
@@ -39,11 +39,13 @@ class Window(QtWidgets.QWidget):
         param_labels.addWidget(self.azimuth_l)
 
         self.area_le = QtWidgets.QLineEdit("1000")
-        self.module_le = QtWidgets.QLineEdit("0")
+        self.module_le = QtWidgets.QComboBox()
+        self.module_le.insertItems(0,["0","1","2"])
         self.lat_le = QtWidgets.QLineEdit("42.3")
         self.lon_le = QtWidgets.QLineEdit("-83.7")
         self.losses_le = QtWidgets.QLineEdit("14")
-        self.array_le = QtWidgets.QLineEdit("0")
+        self.array_le = QtWidgets.QComboBox()
+        self.array_le.insertItems(0, ["0", "1", "2", "3", "4"])
         self.tilt_le = QtWidgets.QLineEdit("34")
         self.azimuth_le = QtWidgets.QLineEdit("180")
 
@@ -65,7 +67,7 @@ class Window(QtWidgets.QWidget):
         left_pane.addWidget(self.submit)
 
         self.output_box = QtWidgets.QPlainTextEdit()
-        self.output_box.setFixedWidth(350)
+        self.output_box.setFixedWidth(500)
 
         container.addLayout(left_pane)
         container.addWidget(self.output_box)
@@ -80,16 +82,21 @@ class Window(QtWidgets.QWidget):
     def run(self):
         global run
         run = PVWatts_API.PVWatts_Run(area=int(self.area_le.text()),
-                                      module_type=int(self.module_le.text()),
+                                      module_type=int(self.module_le.currentText()),
                                       lat=self.lat_le.text(),
                                       lon=self.lon_le.text(),
                                       losses=self.losses_le.text(),
-                                      array_type=self.array_le.text(),
+                                      array_type=self.array_le.currentText(),
                                       tilt=self.tilt_le.text(),
                                       azimuth=self.azimuth_le.text(),
                                       timeframe='hourly')
-        self.output_box.setPlainText(run.describe())
+        if self.first_run:
+            self.output_box.appendPlainText(run.describe())
+            self.first_run = False
+        else:
+            self.output_box.appendPlainText('\n' + run.describe())
 
-app = QtWidgets.QApplication(sys.argv)
-current_run = Window()
-sys.exit(app.exec())
+def run_program():
+    app = QtWidgets.QApplication(sys.argv)
+    current_run = Window()
+    sys.exit(app.exec())

--- a/__main__.py
+++ b/__main__.py
@@ -1,50 +1,95 @@
 #!/usr/bin/env python
+import sys
+from PyQt5 import QtWidgets
+
 import PVWatts_API
 
-standard_fixed = PVWatts_API.PVWatts_Run(area=1, module_type=0,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="0", tilt="34",
-                                    azimuth="180", timeframe="hourly")
 
-standard_rooftop = PVWatts_API.PVWatts_Run(area=1, module_type=0,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="1", tilt="34",
-                                    azimuth="180", timeframe="hourly")
+class Window(QtWidgets.QWidget):
 
-standard_rotating = PVWatts_API.PVWatts_Run(area=1, module_type=0,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="4", tilt="34",
-                                    azimuth="180", timeframe="hourly")
+    def __init__(self):
+        super().__init__()
+        self.init_ui()
 
-premium_fixed = PVWatts_API.PVWatts_Run(area=1, module_type=1,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="0", tilt="34",
-                                    azimuth="180", timeframe="hourly")
+    def init_ui(self):
+        container = QtWidgets.QHBoxLayout()
 
-premium_rooftop = PVWatts_API.PVWatts_Run(area=1, module_type=1,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="1", tilt="34",
-                                    azimuth="180", timeframe="hourly")
+        left_pane = QtWidgets.QVBoxLayout()
 
-premium_rotating = PVWatts_API.PVWatts_Run(area=1, module_type=1,
-                                    lat="42.3", lon="-83.7", losses="14",
-                                    array_type="4", tilt="34",
-                                    azimuth="180", timeframe="hourly")
+        parameters = QtWidgets.QHBoxLayout()
+        param_labels = QtWidgets.QVBoxLayout()
+        param_fields = QtWidgets.QVBoxLayout()
 
-print("Ratios for Standard-Fixed Arrays:")
-standard_fixed.describe()
+        self.area_l = QtWidgets.QLabel("Area: ")
+        self.module_l = QtWidgets.QLabel("Module Type: ")
+        self.lat_l = QtWidgets.QLabel("Lat: ")
+        self.lon_l = QtWidgets.QLabel("Lon: ")
+        self.losses_l = QtWidgets.QLabel("Losses: ")
+        self.array_l = QtWidgets.QLabel("Array Type: ")
+        self.tilt_l = QtWidgets.QLabel("Tilt")
+        self.azimuth_l = QtWidgets.QLabel("Azimuth: ")
 
-print("Ratios for Standard-Rooftop Arrays:")
-standard_rooftop.describe()
+        param_labels.addWidget(self.area_l)
+        param_labels.addWidget(self.module_l)
+        param_labels.addWidget(self.lat_l)
+        param_labels.addWidget(self.lon_l)
+        param_labels.addWidget(self.losses_l)
+        param_labels.addWidget(self.array_l)
+        param_labels.addWidget(self.tilt_l)
+        param_labels.addWidget(self.azimuth_l)
 
-print("Ratios for Standard-Rotating Arrays:")
-standard_rotating.describe()
+        self.area_le = QtWidgets.QLineEdit("1000")
+        self.module_le = QtWidgets.QLineEdit("0")
+        self.lat_le = QtWidgets.QLineEdit("42.3")
+        self.lon_le = QtWidgets.QLineEdit("-83.7")
+        self.losses_le = QtWidgets.QLineEdit("14")
+        self.array_le = QtWidgets.QLineEdit("0")
+        self.tilt_le = QtWidgets.QLineEdit("34")
+        self.azimuth_le = QtWidgets.QLineEdit("180")
 
-print("Ratios for Premium-Fixed Arrays:")
-premium_fixed.describe()
+        param_fields.addWidget(self.area_le)
+        param_fields.addWidget(self.module_le)
+        param_fields.addWidget(self.lat_le)
+        param_fields.addWidget(self.lon_le)
+        param_fields.addWidget(self.losses_le)
+        param_fields.addWidget(self.array_le)
+        param_fields.addWidget(self.tilt_le)
+        param_fields.addWidget(self.azimuth_le)
 
-print("Ratios for Premium-Rooftop Arrays:")
-premium_rooftop.describe()
+        self.submit = QtWidgets.QPushButton("Submit")
 
-print("Ratios for Premium-Rotating Arrays:")
-premium_rotating.describe()
+        parameters.addLayout(param_labels)
+        parameters.addLayout(param_fields)
+
+        left_pane.addLayout(parameters)
+        left_pane.addWidget(self.submit)
+
+        self.output_box = QtWidgets.QPlainTextEdit()
+        self.output_box.setFixedWidth(350)
+
+        container.addLayout(left_pane)
+        container.addWidget(self.output_box)
+
+
+
+        self.submit.clicked.connect(self.run)
+        self.setLayout(container)
+        self.setWindowTitle("PV Watts Tool")
+        self.show()
+
+    def run(self):
+        global run
+        run = PVWatts_API.PVWatts_Run(area=int(self.area_le.text()),
+                                      module_type=int(self.module_le.text()),
+                                      lat=self.lat_le.text(),
+                                      lon=self.lon_le.text(),
+                                      losses=self.losses_le.text(),
+                                      array_type=self.array_le.text(),
+                                      tilt=self.tilt_le.text(),
+                                      azimuth=self.azimuth_le.text(),
+                                      timeframe='hourly')
+        self.output_box.setPlainText(run.describe())
+
+app = QtWidgets.QApplication(sys.argv)
+current_run = Window()
+sys.exit(app.exec())


### PR DESCRIPTION
The tool now uses a GUI (built with PyQT5). Parameters are input in the left pane, output is printed to the right. 

You should be able to run the tool with a few simple commands now. From python interpreter, enter the following:
    > import PVWatts_Tool
    > PVWatts_Tool.run_program()

The tool has a few requisites:
• Pandas
• Numpy
• PyQt5
(These three are readily available with the [Anaconda](https://www.continuum.io/downloads) distribution of Python 3.6)
